### PR TITLE
Include ipv6 ranges in the AWS list

### DIFF
--- a/src/providers/aws.js
+++ b/src/providers/aws.js
@@ -8,5 +8,5 @@ module.exports = async function () {
         url: 'https://ip-ranges.amazonaws.com/ip-ranges.json',
         json: true,
     });
-    return response.data.prefixes.map((obj) => obj.ip_prefix);
+    return response.data.prefixes.map((obj) => obj.ip_prefix).concat(response.data.ipv6_prefixes.map((obj) => obj.ipv6_prefix));
 };


### PR DESCRIPTION
It looks like we only grabbed the ipv4 list from the AWS json file, this one liner fix includes the ipv6_prefixes as well.